### PR TITLE
Updated README.md to reflect correct notebook directory url

### DIFF
--- a/installation/README.md
+++ b/installation/README.md
@@ -1,4 +1,4 @@
-All code is provided within Jupyter notebooks [in this directory](https://github.com/jonkrohn/DLTFpT/blob/master/notebooks/). These notebooks are intended for use within the (free) [Colab cloud environment](https://colab.research.google.com), which requires no installation.
+All code is provided within Jupyter notebooks [in this directory](https://github.com/jonkrohn/ML-foundations/tree/master/notebooks). These notebooks are intended for use within the (free) [Colab cloud environment](https://colab.research.google.com), which requires no installation.
 
 Nothing else in this directory matters at this time. Feel free to ignore.
 


### PR DESCRIPTION
The previous url pointed to the Deep Learning notebook repo.